### PR TITLE
Ensure compatibility with recent versions of DCMTK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ endif()
 ADD_EXECUTABLE(dcmcjp2k dcmcjp2k.cc)
 TARGET_LINK_LIBRARIES(dcmcjp2k
 	${DCMTK_LIBRARIES}
-	openjp2
+	${OPENJPEG_LIBRARIES}
 	fmjpeg2k
 	)
 
 ADD_EXECUTABLE(dcmdjp2k dcmdjp2k.cc)
 TARGET_LINK_LIBRARIES(dcmdjp2k
 	${DCMTK_LIBRARIES}
-	openjp2
+	${OPENJPEG_LIBRARIES}
 	fmjpeg2k
 	)
 
@@ -67,7 +67,7 @@ add_library(fmjpeg2k ${fmjpeg2k_SRCS})
 set(fmjpeg2k_LIBRARY_NAME fmjpeg2k)
 TARGET_LINK_LIBRARIES(fmjpeg2k
 	${DCMTK_LIBRARIES}
-	openjp2
+	${OPENJPEG_LIBRARIES}
 	)
 
 include(GenerateExportHeader)

--- a/djcodecd.cc
+++ b/djcodecd.cc
@@ -197,6 +197,19 @@ OFCondition DJPEG2KDecoderBase::decode(
 }
 
 
+OFCondition DJPEG2KDecoderBase::decode(
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * pixSeq,
+    DcmPolymorphOBOW& uncompressedPixelData,
+    const DcmCodecParameter * cp,
+    const DcmStack& objStack,
+    OFBool& removeOldRep) const
+{
+  // removeOldRep is left as it is, pixel data in original DICOM dataset is not modified
+  return decode(fromRepParam, pixSeq, uncompressedPixelData, cp, objStack);
+}
+
+
 OFCondition DJPEG2KDecoderBase::decodeFrame(
     const DcmRepresentationParameter * /* fromParam */,
     DcmPixelSequence *fromPixSeq,
@@ -530,6 +543,19 @@ OFCondition DJPEG2KDecoderBase::encode(
 
 
 OFCondition DJPEG2KDecoderBase::encode(
+  const Uint16 * pixelData,
+  const Uint32 length,
+  const DcmRepresentationParameter * toRepParam,
+  DcmPixelSequence * & pixSeq,
+  const DcmCodecParameter *cp,
+  DcmStack & objStack,
+  OFBool& removeOldRep) const
+{
+  return EC_IllegalCall;
+}
+
+
+OFCondition DJPEG2KDecoderBase::encode(
     const E_TransferSyntax /* fromRepType */,
     const DcmRepresentationParameter * /* fromRepParam */,
     DcmPixelSequence * /* fromPixSeq */,
@@ -539,6 +565,20 @@ OFCondition DJPEG2KDecoderBase::encode(
     DcmStack & /* objStack */) const
 {
   // we don't support re-coding for now.
+  return EC_IllegalCall;
+}
+
+
+OFCondition DJPEG2KDecoderBase::encode(
+  const E_TransferSyntax fromRepType,
+  const DcmRepresentationParameter * fromRepParam,
+  DcmPixelSequence * fromPixSeq,
+  const DcmRepresentationParameter * toRepParam,
+  DcmPixelSequence * & toPixSeq,
+  const DcmCodecParameter * cp,
+  DcmStack & objStack,
+  OFBool& removeOldRep) const
+{
   return EC_IllegalCall;
 }
 

--- a/djcodece.cc
+++ b/djcodece.cc
@@ -119,6 +119,18 @@ OFCondition DJPEG2KEncoderBase::decode(
 }
 
 
+OFCondition DJPEG2KEncoderBase::decode(
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * pixSeq,
+    DcmPolymorphOBOW& uncompressedPixelData,
+    const DcmCodecParameter * cp,
+    const DcmStack& objStack,
+    OFBool& removeOldRep) const
+{
+  return EC_IllegalCall;
+}
+
+
 OFCondition DJPEG2KEncoderBase::decodeFrame(
 	const DcmRepresentationParameter * /* fromParam */ ,
 	DcmPixelSequence * /* fromPixSeq */ ,
@@ -147,6 +159,21 @@ OFCondition DJPEG2KEncoderBase::encode(
 	// we don't support re-coding for now.
 	return EC_IllegalCall;
 }
+
+
+OFCondition DJPEG2KEncoderBase::encode(
+    const E_TransferSyntax fromRepType,
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * fromPixSeq,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & toPixSeq,
+    const DcmCodecParameter * cp,
+    DcmStack & objStack,
+	OFBool& removeOldRep) const
+{
+  return EC_IllegalCall;
+}
+
 
 OFCondition DJPEG2KEncoderBase::encode(
 	const Uint16 * pixelData,
@@ -225,6 +252,20 @@ OFCondition DJPEG2KEncoderBase::encode(
 	}
 
 	return result;
+}
+
+
+OFCondition DJPEG2KEncoderBase::encode(
+    const Uint16 * pixelData,
+    const Uint32 length,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & pixSeq,
+    const DcmCodecParameter *cp,
+    DcmStack & objStack,
+    OFBool& removeOldRep) const
+{
+	// removeOldRep is left as it is, pixel data in original DICOM dataset is not modified
+	return encode(pixelData, length, toRepParam, pixSeq, cp, objStack);
 }
 
 

--- a/include/fmjpeg2k/djcodecd.h
+++ b/include/fmjpeg2k/djcodecd.h
@@ -59,6 +59,28 @@ public:
     const DcmCodecParameter * cp,
     const DcmStack& objStack) const;
 
+  /** decompresses the given pixel sequence and
+   *  stores the result in the given uncompressedPixelData element.
+   *  @param fromRepParam current representation parameter of compressed data, may be NULL
+   *  @param pixSeq compressed pixel sequence
+   *  @param uncompressedPixelData uncompressed pixel data stored in this element
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition decode(
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * pixSeq,
+    DcmPolymorphOBOW& uncompressedPixelData,
+    const DcmCodecParameter * cp,
+    const DcmStack& objStack,
+    OFBool& removeOldRep) const;
+
   /** decompresses a single frame from the given pixel sequence and
    *  stores the result in the given buffer.
    *  @param fromParam representation parameter of current compressed
@@ -117,6 +139,33 @@ public:
     const DcmCodecParameter *cp,
     DcmStack & objStack) const;
 
+  /** compresses the given uncompressed DICOM image and stores
+   *  the result in the given pixSeq element.
+   *  @param pixelData pointer to the uncompressed image data in OW format
+   *    and local byte order
+   *  @param length of the pixel data field in bytes
+   *  @param toRepParam representation parameter describing the desired
+   *    compressed representation (e.g. JPEG quality)
+   *  @param pixSeq compressed pixel sequence (pointer to new DcmPixelSequence object
+   *    allocated on heap) returned in this parameter upon success.
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition encode(
+    const Uint16 * pixelData,
+    const Uint32 length,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & pixSeq,
+    const DcmCodecParameter *cp,
+    DcmStack & objStack,
+    OFBool& removeOldRep) const;
+
   /** transcodes (re-compresses) the given compressed DICOM image and stores
    *  the result in the given toPixSeq element.
    *  @param fromRepType current transfer syntax of the compressed image
@@ -139,6 +188,34 @@ public:
     DcmPixelSequence * & toPixSeq,
     const DcmCodecParameter * cp,
     DcmStack & objStack) const;
+
+  /** transcodes (re-compresses) the given compressed DICOM image and stores
+   *  the result in the given toPixSeq element.
+   *  @param fromRepType current transfer syntax of the compressed image
+   *  @param fromRepParam current representation parameter of compressed data, may be NULL
+   *  @param fromPixSeq compressed pixel sequence
+   *  @param toRepParam representation parameter describing the desired
+   *    new compressed representation (e.g. JPEG quality)
+   *  @param toPixSeq compressed pixel sequence (pointer to new DcmPixelSequence object
+   *    allocated on heap) returned in this parameter upon success.
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition encode(
+    const E_TransferSyntax fromRepType,
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * fromPixSeq,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & toPixSeq,
+    const DcmCodecParameter * cp,
+    DcmStack & objStack,
+    OFBool& removeOldRep) const;
 
   /** checks if this codec is able to convert from the
    *  given current transfer syntax to the given new

--- a/include/fmjpeg2k/djcodece.h
+++ b/include/fmjpeg2k/djcodece.h
@@ -61,6 +61,28 @@ public:
     const DcmCodecParameter * cp,
     const DcmStack& objStack) const;
 
+  /** decompresses the given pixel sequence and
+   *  stores the result in the given uncompressedPixelData element.
+   *  @param fromRepParam current representation parameter of compressed data, may be NULL
+   *  @param pixSeq compressed pixel sequence
+   *  @param uncompressedPixelData uncompressed pixel data stored in this element
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition decode(
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * pixSeq,
+    DcmPolymorphOBOW& uncompressedPixelData,
+    const DcmCodecParameter * cp,
+    const DcmStack& objStack,
+    OFBool& removeOldRep) const;
+
   /** decompresses a single frame from the given pixel sequence and
    *  stores the result in the given buffer.
    *  @param fromParam representation parameter of current compressed
@@ -119,6 +141,33 @@ public:
     const DcmCodecParameter *cp,
     DcmStack & objStack) const;
 
+  /** compresses the given uncompressed DICOM image and stores
+   *  the result in the given pixSeq element.
+   *  @param pixelData pointer to the uncompressed image data in OW format
+   *    and local byte order
+   *  @param length of the pixel data field in bytes
+   *  @param toRepParam representation parameter describing the desired
+   *    compressed representation (e.g. JPEG quality)
+   *  @param pixSeq compressed pixel sequence (pointer to new DcmPixelSequence object
+   *    allocated on heap) returned in this parameter upon success.
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition encode(
+    const Uint16 * pixelData,
+    const Uint32 length,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & pixSeq,
+    const DcmCodecParameter *cp,
+    DcmStack & objStack,
+    OFBool& removeOldRep) const;
+  
   /** transcodes (re-compresses) the given compressed DICOM image and stores
    *  the result in the given toPixSeq element.
    *  @param fromRepType current transfer syntax of the compressed image
@@ -142,6 +191,34 @@ public:
     const DcmCodecParameter * cp,
     DcmStack & objStack) const;
 
+  /** transcodes (re-compresses) the given compressed DICOM image and stores
+   *  the result in the given toPixSeq element.
+   *  @param fromRepType current transfer syntax of the compressed image
+   *  @param fromRepParam current representation parameter of compressed data, may be NULL
+   *  @param fromPixSeq compressed pixel sequence
+   *  @param toRepParam representation parameter describing the desired
+   *    new compressed representation (e.g. JPEG quality)
+   *  @param toPixSeq compressed pixel sequence (pointer to new DcmPixelSequence object
+   *    allocated on heap) returned in this parameter upon success.
+   *  @param cp codec parameters for this codec
+   *  @param objStack stack pointing to the location of the pixel data
+   *    element in the current dataset.
+   *  @param removeOldRep boolean flag that should be set to false before this method call
+   *    and will be set to true if the codec modifies the DICOM dataset such
+   *    that the pixel data of the original representation may not be usable
+   *    anymore.
+   *  @return EC_Normal if successful, an error code otherwise.
+   */
+  virtual OFCondition encode(
+    const E_TransferSyntax fromRepType,
+    const DcmRepresentationParameter * fromRepParam,
+    DcmPixelSequence * fromPixSeq,
+    const DcmRepresentationParameter * toRepParam,
+    DcmPixelSequence * & toPixSeq,
+    const DcmCodecParameter * cp,
+    DcmStack & objStack,
+    OFBool& removeOldRep) const;
+  
   /** checks if this codec is able to convert from the
    *  given current transfer syntax to the given new
    *  transfer syntax


### PR DESCRIPTION
The `master` branch of DCMTK has introduced a new parameter `OFBool& removeOldRep` for `encode` and `decode` functions in `DcmCodec`. The new parameter is introduced to `fmjpeg2koj` in a backwards-compatible manner.