### PR TITLE
Install shared library in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ install(TARGETS dcmcjp2k EXPORT fmjpeg2kTargets
 install(TARGETS fmjpeg2k EXPORT fmjpeg2kTargets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(


### PR DESCRIPTION
This change allows the fmjpeg2k.dll (when requested, BUILD_SHARED_LIBS=ON) to be installed the bin directory.